### PR TITLE
fix: add @media screen margins for browser preview

### DIFF
--- a/assets/templates/letter-en.html
+++ b/assets/templates/letter-en.html
@@ -41,6 +41,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 25mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: var(--serif);

--- a/assets/templates/letter.html
+++ b/assets/templates/letter.html
@@ -46,6 +46,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 25mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: "TsangerJinKai02", "Source Han Serif SC",

--- a/assets/templates/long-doc-en.html
+++ b/assets/templates/long-doc-en.html
@@ -56,6 +56,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 20mm 22mm 22mm 22mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: var(--serif);

--- a/assets/templates/long-doc.html
+++ b/assets/templates/long-doc.html
@@ -62,6 +62,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 20mm 22mm 22mm 22mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: "TsangerJinKai02", "Source Han Serif SC",

--- a/assets/templates/one-pager-en.html
+++ b/assets/templates/one-pager-en.html
@@ -47,6 +47,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 15mm 18mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: var(--serif);

--- a/assets/templates/one-pager.html
+++ b/assets/templates/one-pager.html
@@ -52,6 +52,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 15mm 18mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: "TsangerJinKai02", "Source Han Serif SC",

--- a/assets/templates/portfolio-en.html
+++ b/assets/templates/portfolio-en.html
@@ -49,6 +49,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 12mm 15mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: var(--serif);

--- a/assets/templates/portfolio.html
+++ b/assets/templates/portfolio.html
@@ -57,6 +57,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 12mm 15mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: "TsangerJinKai02", "Source Han Serif SC",

--- a/assets/templates/resume-en.html
+++ b/assets/templates/resume-en.html
@@ -44,6 +44,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 11mm 13mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: var(--serif);

--- a/assets/templates/resume.html
+++ b/assets/templates/resume.html
@@ -47,6 +47,10 @@
 
   html, body { background: var(--parchment); }
 
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 9mm 13mm; }
+  }
+
   body {
     color: var(--near-black);
     font-family: "TsangerJinKai02", "Noto Serif CJK SC", "DejaVu Serif", "PingFang SC", Georgia, serif;


### PR DESCRIPTION
## Summary

- All 10 templates (5 CN + 5 EN) rely on `@page { margin: ... }` for spacing, which only takes effect in WeasyPrint PDF output and browser print mode
- When opening the HTML directly in a browser, content has zero padding — it stretches edge to edge
- Added `@media screen { body { max-width: 210mm; margin: 0 auto; padding: ...; } }` to each template, with padding values matching the template's own `@page` margin

## Details

| Template | `@page` margin | `@media screen` padding |
|---|---|---|
| long-doc / long-doc-en | 20mm 22mm 22mm 22mm | 20mm 22mm 22mm 22mm |
| one-pager / one-pager-en | 15mm 18mm | 15mm 18mm |
| letter / letter-en | 25mm | 25mm |
| portfolio / portfolio-en | 12mm 15mm | 12mm 15mm |
| resume | 9mm 13mm | 9mm 13mm |
| resume-en | 11mm 13mm | 11mm 13mm |

## Test plan

- [x] `python3 scripts/build.py --check` passes (no CSS violations, tokens in sync)
- [ ] Open any template HTML in browser — verify content is centered with proper margins
- [ ] Generate PDF via WeasyPrint — verify no change in PDF output (screen rules don't affect print)

🤖 Generated with [Claude Code](https://claude.ai/code)