### PR TITLE
feat: add Claude Code plugin manifest and marketplace entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "kami",
+  "description": "Personal typesetting skill for Claude Code.",
+  "owner": {
+    "name": "Tw93",
+    "email": "hitw93@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "kami",
+      "description": "Typeset professional documents: resumes, one-pagers, white papers, letters, portfolios, slide decks. Warm parchment, ink-blue accent, serif-led hierarchy.",
+      "version": "1.3.0",
+      "category": "documents",
+      "source": "./",
+      "homepage": "https://github.com/tw93/Kami"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "kami",
-  "description": "Personal typesetting skill for Claude Code.",
+  "description": "Document typesetting skill for Claude Code.",
   "owner": {
     "name": "Tw93",
     "email": "hitw93@gmail.com"
@@ -9,7 +9,6 @@
     {
       "name": "kami",
       "description": "Typeset professional documents: resumes, one-pagers, white papers, letters, portfolios, slide decks. Warm parchment, ink-blue accent, serif-led hierarchy.",
-      "version": "1.3.0",
       "category": "documents",
       "source": "./",
       "homepage": "https://github.com/tw93/Kami"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "kami",
+  "description": "Typeset professional documents: resumes, one-pagers, white papers, letters, portfolios, slide decks. Warm parchment, ink-blue accent, serif-led hierarchy.",
+  "version": "1.3.0",
+  "author": {
+    "name": "Tw93",
+    "email": "hitw93@gmail.com"
+  },
+  "homepage": "https://github.com/tw93/Kami",
+  "repository": "https://github.com/tw93/Kami",
+  "license": "MIT",
+  "commands": ["./SKILL.md"]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "kami",
   "description": "Typeset professional documents: resumes, one-pagers, white papers, letters, portfolios, slide decks. Warm parchment, ink-blue accent, serif-led hierarchy.",
-  "version": "1.3.0",
   "author": {
     "name": "Tw93",
     "email": "hitw93@gmail.com"
@@ -9,5 +8,5 @@
   "homepage": "https://github.com/tw93/Kami",
   "repository": "https://github.com/tw93/Kami",
   "license": "MIT",
-  "commands": ["./SKILL.md"]
+  "skills": ["./"]
 }

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Part of a trilogy: [Kaku](https://github.com/tw93/Kaku) (書く) writes code, [W
 npx skills add tw93/kami -a claude-code -g -y
 ```
 
+Or via plugin marketplace:
+
+```bash
+/plugin marketplace add tw93/Kami
+/plugin install kami@kami
+```
+
 **Generic agents** (Codex, OpenCode, Pi, and other tools that read from `~/.agents/`)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Part of a trilogy: [Kaku](https://github.com/tw93/Kaku) (書く) writes code, [W
 npx skills add tw93/kami -a claude-code -g -y
 ```
 
-Or via plugin marketplace:
+Or via the Claude Code plugin marketplace:
 
 ```bash
 /plugin marketplace add tw93/Kami

--- a/index-ja.html
+++ b/index-ja.html
@@ -119,6 +119,10 @@
 <pre class="code"><span class="c"># Claude Code</span>
 npx skills add tw93/kami -a claude-code -g -y
 
+<span class="c"># Claude Code plugin marketplace</span>
+/plugin marketplace add tw93/Kami
+/plugin install kami@kami
+
 <span class="c"># Codex</span>
 npx skills add tw93/kami -a codex -g -y</pre>
     <p class="section-lede" style="font-size:14px;">Claude Desktop の場合は <a href="https://github.com/tw93/kami/releases/latest/download/kami.zip" style="color:var(--brand); text-decoration:none; font-weight:500;">kami.zip</a> をダウンロードし、Customize &gt; Skills &gt; "+" &gt; Create skill からそのままアップロードします。</p>
@@ -573,7 +577,7 @@ beauty   = constraints × <span class="k">intention</span> ÷ noise</pre>
       </div>
       <div class="faq-pair">
         <dt>セットアップ方法は？</dt>
-        <dd>3通り。Claude Code：<code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a claude-code -g -y</code>。汎用エージェント：<code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a '*' -g -y</code>。Claude Desktop：GitHub Releasesからkami.zipをダウンロードし、カスタマイズ &gt; スキルでアップロード。</dd>
+        <dd>4通り。Claude Code：<code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a claude-code -g -y</code>、またはプラグインマーケットプレイスで <code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">/plugin marketplace add tw93/Kami</code> のあと <code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">/plugin install kami@kami</code>。汎用エージェント：<code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a '*' -g -y</code>。Claude Desktop：GitHub Releasesからkami.zipをダウンロードし、カスタマイズ &gt; スキルでアップロード。</dd>
       </div>
       <div class="faq-pair">
         <dt>対応言語は？</dt>

--- a/index-zh.html
+++ b/index-zh.html
@@ -118,6 +118,10 @@
 <pre class="code"><span class="c"># Claude Code</span>
 npx skills add tw93/kami -a claude-code -g -y
 
+<span class="c"># Claude Code plugin marketplace</span>
+/plugin marketplace add tw93/Kami
+/plugin install kami@kami
+
 <span class="c"># Codex</span>
 npx skills add tw93/kami -a codex -g -y</pre>
     <p class="section-lede" style="font-size:14px;">Claude Desktop：下载 <a href="https://github.com/tw93/kami/releases/latest/download/kami.zip" style="color:var(--brand); text-decoration:none; font-weight:500;">kami.zip</a>，在 Customize &gt; Skills &gt; "+" &gt; Create skill 中直接上传。</p>
@@ -602,7 +606,7 @@ beauty   = constraints × <span class="k">intention</span> ÷ noise</pre>
       </div>
       <div class="faq-pair">
         <dt>怎么安装？</dt>
-        <dd>三种方式。Claude Code：<code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a claude-code -g -y</code>。通用 agent：<code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a '*' -g -y</code>。Claude Desktop：从 GitHub Releases 下载 kami.zip，在自定义 &gt; Skills 中上传即可。</dd>
+        <dd>四种方式。Claude Code：<code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a claude-code -g -y</code>，或插件市场：<code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">/plugin marketplace add tw93/Kami</code> 后执行 <code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">/plugin install kami@kami</code>。通用 agent：<code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a '*' -g -y</code>。Claude Desktop：从 GitHub Releases 下载 kami.zip，在自定义 &gt; Skills 中上传即可。</dd>
       </div>
       <div class="faq-pair">
         <dt>支持哪些语言？</dt>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         "name": "How do I set up Kami?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Three ways. Claude Code: npx skills add tw93/kami. Generic agents: npx skills add tw93/kami -a '*'. Claude Desktop: download kami.zip from GitHub Releases and upload it in Skills settings."
+          "text": "Four ways. Claude Code: npx skills add tw93/kami, or use the plugin marketplace with /plugin marketplace add tw93/Kami and /plugin install kami@kami. Generic agents: npx skills add tw93/kami -a '*'. Claude Desktop: download kami.zip from GitHub Releases and upload it in Skills settings."
         }
       },
       {
@@ -141,6 +141,10 @@
     </div>
 <pre class="code"><span class="c"># Claude Code</span>
 npx skills add tw93/kami -a claude-code -g -y
+
+<span class="c"># Claude Code plugin marketplace</span>
+/plugin marketplace add tw93/Kami
+/plugin install kami@kami
 
 <span class="c"># Codex</span>
 npx skills add tw93/kami -a codex -g -y</pre>
@@ -596,7 +600,7 @@ beauty   = constraints × <span class="k">intention</span> ÷ noise</pre>
       </div>
       <div class="faq-pair">
         <dt>How do I set it up?</dt>
-        <dd>Three ways. Claude Code: <code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a claude-code -g -y</code>. Generic agents like Codex or OpenCode: <code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a '*' -g -y</code>. Claude Desktop: download kami.zip from GitHub Releases and upload it in Customize &gt; Skills. No slash command needed, the skill auto-triggers from natural requests.</dd>
+        <dd>Four ways. Claude Code: <code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a claude-code -g -y</code>, or plugin marketplace: <code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">/plugin marketplace add tw93/Kami</code> then <code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">/plugin install kami@kami</code>. Generic agents like Codex or OpenCode: <code style="font-family:var(--mono); font-size:0.9em; color:var(--brand);">npx skills add tw93/kami -a '*' -g -y</code>. Claude Desktop: download kami.zip from GitHub Releases and upload it in Customize &gt; Skills. No slash command needed, the skill auto-triggers from natural requests.</dd>
       </div>
       <div class="faq-pair">
         <dt>What languages does it support?</dt>

--- a/llms.txt
+++ b/llms.txt
@@ -14,6 +14,12 @@ Kami is a layout design system for the AI era. Give Claude (or any LLM) a brief,
 - [Chinese showcase](https://kami.tw93.fun/index-zh.html): Chinese version
 - [GitHub](https://github.com/tw93/kami): Source code and templates
 
+## Install
+- Claude Code: `npx skills add tw93/kami -a claude-code -g -y`
+- Claude Code plugin marketplace: `/plugin marketplace add tw93/Kami`, then `/plugin install kami@kami`
+- Generic agents: `npx skills add tw93/kami -a '*' -g -y`
+- Claude Desktop: download `kami.zip` from GitHub Releases and upload it in Skills settings
+
 ## Templates
 - One-pager, Letter, Resume, Long document, Portfolio, Slides, Equity report, Changelog
 - 14 diagram types: flowchart, sequence, state, class, ER, timeline, mindmap, tree, radar, pie, Gantt, Sankey, force-directed, architecture


### PR DESCRIPTION
## What problem this solves

kami currently cannot be installed via Claude Code plugin marketplace workflows. The existing paths are `npx skills add tw93/kami` and the Claude Desktop ZIP.

## What this PR does

Adds `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` so kami can be installed via:

```bash
/plugin marketplace add tw93/Kami
/plugin install kami@kami
```

The plugin manifest uses `"skills": ["./"]` so Claude Code loads the root `SKILL.md` as a plugin skill while preserving the existing single-skill repository layout. The manifest intentionally omits a fixed plugin version so GitHub marketplace installs resolve updates from the source commit rather than requiring a second version field to maintain.

`README.md`, the public pages, and `llms.txt` include matching install instructions.

## What is unchanged

- SKILL.md, references, scripts, assets, and HTML templates are untouched.
- The `npx skills add tw93/kami` install path is unaffected.
- The Claude Desktop ZIP install is unaffected.

## Tested

Contributor verified this branch with `/plugin marketplace add`, `/plugin install`, and `/reload-plugins`.

Maintainer validation:

```bash
claude plugin validate .
python3 -m json.tool .claude-plugin/plugin.json
python3 -m json.tool .claude-plugin/marketplace.json
git diff --check
```

Also parsed JSON-LD blocks in `index.html`, `index-zh.html`, and `index-ja.html`. `python3 scripts/build.py --check` still reports existing slide line-height violations in files outside this PRs change scope.