### PR TITLE
refactor(marketplace): drop skills/strict after Claude Code plugin fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,9 +11,7 @@
       "description": "Typeset professional documents: resumes, one-pagers, white papers, letters, portfolios, slide decks. Warm parchment, ink-blue accent, serif-led hierarchy.",
       "category": "documents",
       "source": "./",
-      "homepage": "https://github.com/tw93/kami",
-      "skills": ["./"],
-      "strict": false
+      "homepage": "https://github.com/tw93/kami"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The landing-page template in action: three products, one constraint set.
 npx skills add tw93/kami -a claude-code -g -y
 ```
 
-**Claude Code plugin marketplace** (requires Claude Code v2.1.143+)
+**Claude Code plugin marketplace** (requires Claude Code v2.1.142+)
 
 ```bash
 /plugin marketplace add tw93/kami

--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ The landing-page template in action: three products, one constraint set.
 npx skills add tw93/kami -a claude-code -g -y
 ```
 
-Note: Claude Code 2.1.136-2.1.138 currently rejects root skill paths during marketplace install. Use the `npx skills` command above until the upstream path validation regression is fixed.
+**Claude Code plugin marketplace** (requires Claude Code v2.1.143+)
+
+```bash
+/plugin marketplace add tw93/kami
+/plugin install kami@kami
+```
 
 **Generic agents** (Codex, OpenCode, Pi, and other tools that read from `~/.agents/`)
 

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@ Kami is a layout design system for the AI era. Give Claude (or any LLM) a brief,
 
 ## Install
 - Claude Code: `npx skills add tw93/kami -a claude-code -g -y`
-- Claude Code plugin marketplace (v2.1.143+): `/plugin marketplace add tw93/kami && /plugin install kami@kami`
+- Claude Code plugin marketplace (v2.1.142+): `/plugin marketplace add tw93/kami && /plugin install kami@kami`
 - Generic agents: `npx skills add tw93/kami -a '*' -g -y`
 - Claude Desktop: download `kami.zip` from GitHub Releases and upload it in Skills settings
 

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@ Kami is a layout design system for the AI era. Give Claude (or any LLM) a brief,
 
 ## Install
 - Claude Code: `npx skills add tw93/kami -a claude-code -g -y`
-- Claude Code plugin marketplace: temporarily affected in Claude Code 2.1.136-2.1.138; prefer the `npx skills` command above until upstream fixes root skill path validation
+- Claude Code plugin marketplace (v2.1.143+): `/plugin marketplace add tw93/kami && /plugin install kami@kami`
 - Generic agents: `npx skills add tw93/kami -a '*' -g -y`
 - Claude Desktop: download `kami.zip` from GitHub Releases and upload it in Skills settings
 


### PR DESCRIPTION
## 背景

[`anthropics/claude-code#57570`](https://github.com/anthropics/claude-code/issues/57570) 在 v2.1.136-v2.1.141 期间把 `"skills": ["./"]` 误判为 `path escapes plugin directory`，上游已在 [**v2.1.142**](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21142) 修复。[**v2.1.143**](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21143) 又加了一条自动识别：plugin 根目录有 `SKILL.md`、没有 `skills/` 子目录时，Claude Code 直接把它注册成 skill。

kami 仓库根目录有 `SKILL.md`、无 `skills/` 子目录，对应 v2.1.143 自动识别的条件。`marketplace.json` 里的 `"skills": ["./"]` 和 `"strict": false` 不再需要。

本仓库 #19 当时记录了这次 regression 对 kami 的影响，上游修复后已关闭。

## 改动

- `.claude-plugin/marketplace.json`：删 kami 条目里的 `"skills": ["./"]` 和 `"strict": false`。
- `README.md`：删过时 Note，加 marketplace 安装子章节，标题标注 v2.1.143+ 最低版本。
- `llms.txt`：把 "temporarily affected" 那行换成 marketplace 安装命令。

`npx skills add tw93/kami -a claude-code -g -y` 这条路径不动，Claude Code v2.1.143 之前的用户继续走它。

## 验证

实测 Claude Code **v2.1.143**：

- **本地路径**：`/plugin marketplace add <local-checkout>` + `/plugin install kami@kami` → `/doctor` 无 error，`/kami:kami` 激活。
- **远程路径**：`/plugin marketplace add qishaoyumu/Kami@refactor/claude-code-marketplace` + `/plugin install kami@kami` → `/doctor` 无 error，`/kami:kami` 激活。
- **Lint**：`python3 scripts/build.py --check` 返回 `OK: no violations across 34 templates` 和 `OK: tokens in sync across 34 template(s)`。
