### PR TITLE
fix(resume): unify project-block placeholder hints (CN/EN/KO) + add SKILL.md recruiter pass

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -448,6 +448,21 @@ python3 scripts/build.py --check-density   # flags >25% (WARN) / >50% (SPARSE) t
 
 If a body page (not cover, not last page) gets a SPARSE warning, treat it as a draft defect and re-author with the merge rule.
 
+## Step 4.2 · Resume recruiter pass (resume only)
+
+Mechanical checks (`--check-placeholders`, `--check-resume-balance`, `--check-density`) validate structure and layout, not prose. A resume can pass all of them and still read broken. After filling and before building, reread every project card the way a recruiter would, against four points:
+
+| Row | Passes when |
+|---|---|
+| Role · 角色 | Says what the project was, why it existed, **and your position in it** — not background alone |
+| Actions · 动作 | Verb-led sentences, one concrete approach per sentence — not a comma-separated task dump |
+| Impact · 结果 | Reads as an outcome (deliverable, number, or scope), not a restatement of the process |
+| All three | No row repeats another row's information |
+
+Fix a failing row by rewriting from the source material. If the source cannot support a row (for example, no outcome fact exists), ask the user for the missing fact — do not pad and do not fall back to generic claims ("保障稳定运行", "improved efficiency").
+
+This pass is internal: run it silently; surface it only when a row cannot be fixed without new information from the user.
+
 ## Step 4.5 · Auto-select output format
 
 Do not ask the user which format to export. Decide from context:

--- a/SKILL.md
+++ b/SKILL.md
@@ -450,16 +450,9 @@ If a body page (not cover, not last page) gets a SPARSE warning, treat it as a d
 
 ## Step 4.2 · Resume recruiter pass (resume only)
 
-Mechanical checks (`--check-placeholders`, `--check-resume-balance`, `--check-density`) validate structure and layout, not prose. A resume can pass all of them and still read broken. After filling and before building, reread every project card the way a recruiter would, against four points:
+Mechanical checks (`--check-placeholders`, `--check-resume-balance`, `--check-density`) validate structure and layout, not prose. A resume can pass all of them and still read broken. After filling and before building, reread every project card the way a recruiter would, against the row definitions in `references/resume-writing.md` ("What goes in each row"): Role carries your position in the project, not background alone; Actions are verb-led, one concrete approach per sentence; Impact reads as an outcome, not a restatement of the process. One cross-row check on top: no row repeats another row's information.
 
-| Row | Passes when |
-|---|---|
-| Role · 角色 | Says what the project was, why it existed, **and your position in it** — not background alone |
-| Actions · 动作 | Verb-led sentences, one concrete approach per sentence — not a comma-separated task dump |
-| Impact · 结果 | Reads as an outcome (deliverable, number, or scope), not a restatement of the process |
-| All three | No row repeats another row's information |
-
-Fix a failing row by rewriting from the source material. If the source cannot support a row (for example, no outcome fact exists), ask the user for the missing fact — do not pad and do not fall back to generic claims ("保障稳定运行", "improved efficiency").
+Fix a failing row by rewriting from the source material. If the source cannot support a row (for example, no outcome fact exists), ask the user for the missing fact. Do not pad, and do not fall back to generic claims ("保障稳定运行", "improved efficiency").
 
 This pass is internal: run it silently; surface it only when a row cannot be fixed without new information from the user.
 

--- a/assets/templates/resume-en.html
+++ b/assets/templates/resume-en.html
@@ -549,15 +549,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">Role</div>
-        <div class="proj-text">{{~40 words.}}</div>
+        <div class="proj-text">{{~40 words: what the project is, why it existed, what your seat at the table was.}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">Actions</div>
-        <div class="proj-text">{{~55 words.}}</div>
+        <div class="proj-text">{{~55 words: technical approach, key decisions, execution path.}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">Impact</div>
-        <div class="proj-text">{{~65 words, include <span class="hl">key figures</span>.}}</div>
+        <div class="proj-text">{{~65 words: numbers-first. Highlight <span class="hl">1-2 key figures</span>.}}</div>
       </div>
     </div>
   </div>
@@ -571,15 +571,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">Role</div>
-        <div class="proj-text">{{Project context and your seat.}}</div>
+        <div class="proj-text">{{~40 words: what the project is, why it existed, what your seat at the table was.}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">Actions</div>
-        <div class="proj-text">{{Execution path.}}</div>
+        <div class="proj-text">{{~55 words: technical approach, key decisions, execution path.}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">Impact</div>
-        <div class="proj-text">{{Quantifiable outcome with <span class="hl">key figures</span>.}}</div>
+        <div class="proj-text">{{~65 words: numbers-first. Highlight <span class="hl">1-2 key figures</span>.}}</div>
       </div>
     </div>
   </div>

--- a/assets/templates/resume-ko.html
+++ b/assets/templates/resume-ko.html
@@ -606,15 +606,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">역할</div>
-        <div class="proj-text">{{~60자}}</div>
+        <div class="proj-text">{{~60자: 프로젝트 개요 + 배경 + 본인 역할}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">행동</div>
-        <div class="proj-text">{{~80자}}</div>
+        <div class="proj-text">{{~80자: 기술 방안 / 핵심 의사결정 / 실행 경로}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">결과</div>
-        <div class="proj-text">{{~100자, <span class="hl">핵심 수치</span> 포함}}</div>
+        <div class="proj-text">{{~100자: 수치 중심. <span class="hl">핵심 수치</span> 1-2곳 하이라이트.}}</div>
       </div>
     </div>
   </div>
@@ -628,15 +628,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">역할</div>
-        <div class="proj-text">{{프로젝트 배경과 포지션}}</div>
+        <div class="proj-text">{{~60자: 프로젝트 개요 + 배경 + 본인 역할}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">행동</div>
-        <div class="proj-text">{{실행 경로}}</div>
+        <div class="proj-text">{{~80자: 기술 방안 / 핵심 의사결정 / 실행 경로}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">결과</div>
-        <div class="proj-text">{{정량적 결과, <span class="hl">핵심 수치</span> 포함}}</div>
+        <div class="proj-text">{{~100자: 수치 중심. <span class="hl">핵심 수치</span> 1-2곳 하이라이트.}}</div>
       </div>
     </div>
   </div>

--- a/assets/templates/resume.html
+++ b/assets/templates/resume.html
@@ -608,15 +608,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">角色</div>
-        <div class="proj-text">{{~60 字}}</div>
+        <div class="proj-text">{{~60 字：项目是什么 + 为什么做 + 你的位置}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">动作</div>
-        <div class="proj-text">{{~80 字}}</div>
+        <div class="proj-text">{{~80 字：技术方案 / 关键决策 / 执行路径}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">结果</div>
-        <div class="proj-text">{{~100 字，含 <span class="hl">关键数字</span>}}</div>
+        <div class="proj-text">{{~100 字：数据为王。<span class="hl">关键数字</span> 高亮 1-2 处。}}</div>
       </div>
     </div>
   </div>
@@ -630,15 +630,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">角色</div>
-        <div class="proj-text">{{项目背景和定位}}</div>
+        <div class="proj-text">{{~60 字：项目是什么 + 为什么做 + 你的位置}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">动作</div>
-        <div class="proj-text">{{执行路径}}</div>
+        <div class="proj-text">{{~80 字：技术方案 / 关键决策 / 执行路径}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">结果</div>
-        <div class="proj-text">{{可量化结果，含 <span class="hl">关键数字</span>}}</div>
+        <div class="proj-text">{{~100 字：数据为王。<span class="hl">关键数字</span> 高亮 1-2 处。}}</div>
       </div>
     </div>
   </div>

--- a/plugins/kami/skills/kami/SKILL.md
+++ b/plugins/kami/skills/kami/SKILL.md
@@ -448,6 +448,21 @@ python3 scripts/build.py --check-density   # flags >25% (WARN) / >50% (SPARSE) t
 
 If a body page (not cover, not last page) gets a SPARSE warning, treat it as a draft defect and re-author with the merge rule.
 
+## Step 4.2 · Resume recruiter pass (resume only)
+
+Mechanical checks (`--check-placeholders`, `--check-resume-balance`, `--check-density`) validate structure and layout, not prose. A resume can pass all of them and still read broken. After filling and before building, reread every project card the way a recruiter would, against four points:
+
+| Row | Passes when |
+|---|---|
+| Role · 角色 | Says what the project was, why it existed, **and your position in it** — not background alone |
+| Actions · 动作 | Verb-led sentences, one concrete approach per sentence — not a comma-separated task dump |
+| Impact · 结果 | Reads as an outcome (deliverable, number, or scope), not a restatement of the process |
+| All three | No row repeats another row's information |
+
+Fix a failing row by rewriting from the source material. If the source cannot support a row (for example, no outcome fact exists), ask the user for the missing fact — do not pad and do not fall back to generic claims ("保障稳定运行", "improved efficiency").
+
+This pass is internal: run it silently; surface it only when a row cannot be fixed without new information from the user.
+
 ## Step 4.5 · Auto-select output format
 
 Do not ask the user which format to export. Decide from context:

--- a/plugins/kami/skills/kami/SKILL.md
+++ b/plugins/kami/skills/kami/SKILL.md
@@ -450,16 +450,9 @@ If a body page (not cover, not last page) gets a SPARSE warning, treat it as a d
 
 ## Step 4.2 · Resume recruiter pass (resume only)
 
-Mechanical checks (`--check-placeholders`, `--check-resume-balance`, `--check-density`) validate structure and layout, not prose. A resume can pass all of them and still read broken. After filling and before building, reread every project card the way a recruiter would, against four points:
+Mechanical checks (`--check-placeholders`, `--check-resume-balance`, `--check-density`) validate structure and layout, not prose. A resume can pass all of them and still read broken. After filling and before building, reread every project card the way a recruiter would, against the row definitions in `references/resume-writing.md` ("What goes in each row"): Role carries your position in the project, not background alone; Actions are verb-led, one concrete approach per sentence; Impact reads as an outcome, not a restatement of the process. One cross-row check on top: no row repeats another row's information.
 
-| Row | Passes when |
-|---|---|
-| Role · 角色 | Says what the project was, why it existed, **and your position in it** — not background alone |
-| Actions · 动作 | Verb-led sentences, one concrete approach per sentence — not a comma-separated task dump |
-| Impact · 结果 | Reads as an outcome (deliverable, number, or scope), not a restatement of the process |
-| All three | No row repeats another row's information |
-
-Fix a failing row by rewriting from the source material. If the source cannot support a row (for example, no outcome fact exists), ask the user for the missing fact — do not pad and do not fall back to generic claims ("保障稳定运行", "improved efficiency").
+Fix a failing row by rewriting from the source material. If the source cannot support a row (for example, no outcome fact exists), ask the user for the missing fact. Do not pad, and do not fall back to generic claims ("保障稳定运行", "improved efficiency").
 
 This pass is internal: run it silently; surface it only when a row cannot be fixed without new information from the user.
 

--- a/plugins/kami/skills/kami/assets/templates/resume-en.html
+++ b/plugins/kami/skills/kami/assets/templates/resume-en.html
@@ -549,15 +549,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">Role</div>
-        <div class="proj-text">{{~40 words.}}</div>
+        <div class="proj-text">{{~40 words: what the project is, why it existed, what your seat at the table was.}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">Actions</div>
-        <div class="proj-text">{{~55 words.}}</div>
+        <div class="proj-text">{{~55 words: technical approach, key decisions, execution path.}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">Impact</div>
-        <div class="proj-text">{{~65 words, include <span class="hl">key figures</span>.}}</div>
+        <div class="proj-text">{{~65 words: numbers-first. Highlight <span class="hl">1-2 key figures</span>.}}</div>
       </div>
     </div>
   </div>
@@ -571,15 +571,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">Role</div>
-        <div class="proj-text">{{Project context and your seat.}}</div>
+        <div class="proj-text">{{~40 words: what the project is, why it existed, what your seat at the table was.}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">Actions</div>
-        <div class="proj-text">{{Execution path.}}</div>
+        <div class="proj-text">{{~55 words: technical approach, key decisions, execution path.}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">Impact</div>
-        <div class="proj-text">{{Quantifiable outcome with <span class="hl">key figures</span>.}}</div>
+        <div class="proj-text">{{~65 words: numbers-first. Highlight <span class="hl">1-2 key figures</span>.}}</div>
       </div>
     </div>
   </div>

--- a/plugins/kami/skills/kami/assets/templates/resume-ko.html
+++ b/plugins/kami/skills/kami/assets/templates/resume-ko.html
@@ -606,15 +606,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">역할</div>
-        <div class="proj-text">{{~60자}}</div>
+        <div class="proj-text">{{~60자: 프로젝트 개요 + 배경 + 본인 역할}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">행동</div>
-        <div class="proj-text">{{~80자}}</div>
+        <div class="proj-text">{{~80자: 기술 방안 / 핵심 의사결정 / 실행 경로}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">결과</div>
-        <div class="proj-text">{{~100자, <span class="hl">핵심 수치</span> 포함}}</div>
+        <div class="proj-text">{{~100자: 수치 중심. <span class="hl">핵심 수치</span> 1-2곳 하이라이트.}}</div>
       </div>
     </div>
   </div>
@@ -628,15 +628,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">역할</div>
-        <div class="proj-text">{{프로젝트 배경과 포지션}}</div>
+        <div class="proj-text">{{~60자: 프로젝트 개요 + 배경 + 본인 역할}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">행동</div>
-        <div class="proj-text">{{실행 경로}}</div>
+        <div class="proj-text">{{~80자: 기술 방안 / 핵심 의사결정 / 실행 경로}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">결과</div>
-        <div class="proj-text">{{정량적 결과, <span class="hl">핵심 수치</span> 포함}}</div>
+        <div class="proj-text">{{~100자: 수치 중심. <span class="hl">핵심 수치</span> 1-2곳 하이라이트.}}</div>
       </div>
     </div>
   </div>

--- a/plugins/kami/skills/kami/assets/templates/resume.html
+++ b/plugins/kami/skills/kami/assets/templates/resume.html
@@ -608,15 +608,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">角色</div>
-        <div class="proj-text">{{~60 字}}</div>
+        <div class="proj-text">{{~60 字：项目是什么 + 为什么做 + 你的位置}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">动作</div>
-        <div class="proj-text">{{~80 字}}</div>
+        <div class="proj-text">{{~80 字：技术方案 / 关键决策 / 执行路径}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">结果</div>
-        <div class="proj-text">{{~100 字，含 <span class="hl">关键数字</span>}}</div>
+        <div class="proj-text">{{~100 字：数据为王。<span class="hl">关键数字</span> 高亮 1-2 处。}}</div>
       </div>
     </div>
   </div>
@@ -630,15 +630,15 @@
     <div class="proj-lines">
       <div class="proj-row">
         <div class="proj-label">角色</div>
-        <div class="proj-text">{{项目背景和定位}}</div>
+        <div class="proj-text">{{~60 字：项目是什么 + 为什么做 + 你的位置}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">动作</div>
-        <div class="proj-text">{{执行路径}}</div>
+        <div class="proj-text">{{~80 字：技术方案 / 关键决策 / 执行路径}}</div>
       </div>
       <div class="proj-row">
         <div class="proj-label">结果</div>
-        <div class="proj-text">{{可量化结果，含 <span class="hl">关键数字</span>}}</div>
+        <div class="proj-text">{{~100 字：数据为王。<span class="hl">关键数字</span> 高亮 1-2 处。}}</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION

关联 #38。

### 改动

1. **`assets/templates/resume{,-en,-ko}.html`**(+ `plugins/kami/skills/kami/` 镜像):第 2、3 项目块的占位符从裸字数(`{{~60 字}}`)/退化提示(`{{项目背景和定位}}`)统一为第一块的完整提示。CN 第三块由此找回「你的位置」,与 EN 的 "your seat"、KO 的 "포지션" 对齐。**不动任何 CSS、不改「角色」标签语义。**
2. **`SKILL.md`**(+ 镜像):Step 4.1 之后新增 **Step 4.2 · Resume recruiter pass(resume only)**——填完、build 前,逐项目按四点通读(角色行含本人位置 / 动作行动词开头、一句一做法 / 结果行是结果不是过程 / 三行不互相重复)。agent 内部执行,不产出额外文件,不改 `--verify` 行为。

### 动机

机械校验(placeholders / balance / density)只保结构与排版;一份全部通过校验的简历,文案仍可能不可读(详见 #38,含脱敏复现)。占位符是填写者(人和 agent)实际遵循的最近指令——退化的占位符直接产出退化的文案;第一块写对了、后两块靠猜,是这次问题的直接成因之一。

### 验证

- [x] `python3 scripts/build.py --check` 通过(tokens / cross-template / palette / site facts)
- [x] `python3 scripts/build_metadata.py --check` 通过(plugin 镜像无 drift)
- [x] `python3 scripts/tests/test_build.py` 通过
- [x] 改动仅注释 / 占位符 / 文档,无运行时行为变化;`dist/kami.zip` 未动(按 release 流程由维护者刷新)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
